### PR TITLE
update redi repository to python3

### DIFF
--- a/redi.py
+++ b/redi.py
@@ -38,7 +38,7 @@ def redi(token_list,lexicon,lm):
   for index,token in enumerate(token_list):
     if token in lexicon:
       if len(lexicon[token])==1:
-        token_list[index]=lexicon[token].keys()[0]
+        token_list[index]=list(lexicon[token].keys())[0]
       else:
         if lm==None:
           token_list[index]=sorted(lexicon[token].items(),key=lambda x:-x[1])[0][0]

--- a/redi.py
+++ b/redi.py
@@ -57,10 +57,6 @@ def read_and_write(istream,index,ostream,lm):
   for line in istream:
     if line.strip()=='':
       token_list=redi([e[index] for e in entry_list],lexicon,lm)
-      print('entry list')
-      print(entry_list)
-      print('token list')
-      print(token_list)
       ostream.write(''.join(['\t'.join(entry)+'\t'+token+'\n' for entry, token in zip(entry_list,token_list)])+'\n')
       entry_list=[]
     else:

--- a/redi.py
+++ b/redi.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python
-#-*-coding:utf8-*-
+#!/usr/bin/python3
+#-*-encoding:utf-8-*-
 
 import sys
 import os
 import kenlm
-import cPickle as pickle
+import pickle
 from random import randint
 
 tm_lambda=0.2
@@ -57,10 +57,14 @@ def read_and_write(istream,index,ostream,lm):
   for line in istream:
     if line.strip()=='':
       token_list=redi([e[index] for e in entry_list],lexicon,lm)
-      ostream.write(''.join(['\t'.join(entry)+'\t'+token+'\n' for entry,token in zip(entry_list,token_list)]).encode('utf8')+'\n')
+      print('entry list')
+      print(entry_list)
+      print('token list')
+      print(token_list)
+      ostream.write(''.join(['\t'.join(entry)+'\t'+token+'\n' for entry, token in zip(entry_list,token_list)])+'\n')
       entry_list=[]
     else:
-      entry_list.append(line[:-1].decode('utf8').split('\t'))
+      entry_list.append(line[:-1].split('\t'))
 
 if __name__=='__main__':
   import argparse
@@ -69,7 +73,7 @@ if __name__=='__main__':
   parser.add_argument('-l','--language-model',help='use the language model',action='store_true')
   parser.add_argument('-i','--index',help='index of the column to be processed',type=int,default=0)
   args=parser.parse_args()
-  lexicon=pickle.load(open(os.path.join(reldir,'wikitweetweb.'+args.lang+'.tm')))
+  lexicon=pickle.load(open(os.path.join(reldir,'wikitweetweb.'+args.lang+'.tm'), 'rb'))
   if args.language_model:
     cnf=kenlm.Config()
     cnf.load_method=0

--- a/redi.py
+++ b/redi.py
@@ -52,12 +52,29 @@ def redi(token_list,lexicon,lm):
     token_list[index]=sorted(hypotheses,key=lambda x:-hypotheses[x])[0]
   return apply_uppers(uppers,token_list)
 
+def merge_tokens(entry_list, token_list):
+  merged_text = ''
+  right_pos = 0
+  for (e, t) in zip(entry_list, token_list):
+    left_pos, right_pos_new = e[0].split('.')[3].split('-')
+    left_pos = int(left_pos)
+    right_pos_new = int(right_pos_new)
+
+    if left_pos == right_pos + 1:
+      merged_text += t
+    else:
+      merged_text += ' ' + t
+    right_pos = right_pos_new
+  return merged_text
+
 def read_and_write(istream,index,ostream,lm):
   entry_list=[]
   for line in istream:
     if line.strip()=='':
       token_list=redi([e[index] for e in entry_list],lexicon,lm)
-      ostream.write(''.join(['\t'.join(entry)+'\t'+token+'\n' for entry, token in zip(entry_list,token_list)])+'\n')
+      print(merge_tokens(entry_list, token_list))
+      # print(' '.join(token_list))
+      # ostream.write(''.join(['\t'.join(entry)+'\t'+token+'\n' for entry, token in zip(entry_list,token_list)])+'\n')
       entry_list=[]
     else:
       entry_list.append(line[:-1].split('\t'))


### PR DESCRIPTION
This branch enables diacritic restoration with python3.

The current code does not work when executed with python2. 
The [`kenlm`](https://github.com/kpu/kenlm) repository now supports python3, so upgrading `redi` would be easier than downgrading `kenlm`. 
Additionally, after downloading the [`reldi-tokeniser`](https://github.com/clarinsi/reldi-tokeniser) repository, [this line](https://github.com/clarinsi/reldi-tokeniser/blob/b044b2f8733f1fbfbbce1539d7e4303017d95c6d/tokeniser.py#L1) needs to be changed to `#!/usr/bin/python3`.

Now, the same function works:
`echo 'Jucer nisam bio u skoli' | ../reldi-tokeniser/tokeniser.py hr | ./redi.py hr`